### PR TITLE
enable sql in lieu of a file

### DIFF
--- a/dependencies/requirements.test.txt
+++ b/dependencies/requirements.test.txt
@@ -1,6 +1,6 @@
 black==25.1.0
 flake8==6.1.0
 ipython==8.23.0
-moto==5.0.5
+moto[server]==5.1.1
 pytest==8.2.0
 pytest-asyncio==0.24.0

--- a/ostrich-egg/config.py
+++ b/ostrich-egg/config.py
@@ -219,6 +219,15 @@ class Dataset(BaseModel):
             description="The metrics that will be aggregated; if not specified and no unit-level-id, will just use count(*). If unit-level-id, will use count(distinct unit-level-id)."
         ),
     ] = None
+    sql: Optional[
+        Annotated[
+            Union[str, None],
+            Field(
+                description="The internal SQL to produce the 'view' of this dataset",
+                default=None,
+            ),
+        ]
+    ] = None
 
 
 class DataSource(BaseModel):
@@ -250,22 +259,26 @@ class DatasetConfig(Dataset):
         Annotated[
             Union[str, None],
             Field(
-                description="At present this is called a file for simplicity. It's actually likely a key for s3 or a fully qualified table name for postgres. If not specified, the source is in the datasource."
+                description="At present this is called a file for simplicity. It's actually likely a key for s3 or a fully qualified table name for postgres. If not specified, the source is in the datasource.",
+                default=None,
             ),
         ]
     ] = None
     suppression_strategies: Annotated[
         # List[SuppressionStrategy], discriminator='strategy',
-        Union[
-            List[
-                Union[
-                    ReduceDimensionsStrategy,
-                    MergeDimensionValuesStrategy,
-                    ReplaceWithRedacted,
-                    MarkRedacted,
-                ]
-            ],
-            list,
+        Optional[
+            Union[
+                List[
+                    Union[
+                        ReduceDimensionsStrategy,
+                        MergeDimensionValuesStrategy,
+                        ReplaceWithRedacted,
+                        MarkRedacted,
+                    ]
+                ],
+                list,
+                None,
+            ]
         ],
         Field(
             description="List of suppression strategies",

--- a/ostrich-egg/engine.py
+++ b/ostrich-egg/engine.py
@@ -771,6 +771,12 @@ class Engine:
         ):
             # We are seeing this file reference for the first time, we'll keep track in case we're running in a single process and want to re-use cached data.
             self.connector.load_source_table(source_file=dataset.source_file)
+        elif not dataset.source_file and dataset.sql:
+            logger.info(
+                f"Attempting to create an in-memory table {dataset.name} using: \n{dataset.sql}"
+            )
+            wrapper_sql = f"create or replace table {dataset.name} as {dataset.sql}"
+            self.db.sql(wrapper_sql)
         elif not dataset.source_file:
             # load it in the default manner without a specified table name.
             self.connector.load_source_table()

--- a/tests/data_inputs/test_joins_incidence.csv
+++ b/tests/data_inputs/test_joins_incidence.csv
@@ -1,0 +1,2 @@
+age,zip,year,incidence,expected_to_be_anonymous,expected_to_be_redacted
+18-24,00000,2025,12,FALSE,TRUE

--- a/tests/data_inputs/test_joins_population.csv
+++ b/tests/data_inputs/test_joins_population.csv
@@ -1,0 +1,2 @@
+year,population_method,searchable_type,location,population
+2025,18-24,zip,00000,1000

--- a/tests/test_join_expressions.py
+++ b/tests/test_join_expressions.py
@@ -1,0 +1,174 @@
+import os
+from uuid import uuid4
+
+import boto3
+from moto import mock_aws
+from moto.server import ThreadedMotoServer
+import pytest
+
+from conftest import TEST_DIRECTORY
+from engine import Engine
+from config import (
+    Config,
+    MarkRedacted,
+    MarkRedactedParameters,
+    DatasetConfig,
+    DataSource,
+    Metric,
+    Aggregations,
+)
+
+files = [
+    os.path.join(TEST_DIRECTORY, "data_inputs", f"{name}.csv")
+    for name in ["test_joins_incidence", "test_joins_population"]
+]
+JOIN_SQL = """
+    select
+        incidence.*,
+        population.population
+    from '{incidence_file}' as incidence
+    left join '{population_file}' as population
+        on population.population_method = incidence.age
+        and population.year = incidence.year
+        and population.searchable_type = 'zip'
+        and population.location = incidence.zip
+"""
+
+REDACTION_EXPRESSION = """\
+case
+    when incidence < 11 and population >= 2500 and population < 20000 then true
+    when population >= 20000 then false
+    when population < 2500 then true
+    else false
+end
+"""
+
+INCIDENCE_DIMENSIONS = [
+    "age",
+    "year",
+    "zip",
+    "expected_to_be_anonymous",
+    "expected_to_be_redacted",
+]
+
+INCIDENCE_METRIC = Metric(
+    aggregation=Aggregations.SUM,
+    column="incidence",
+    alias="incidence",
+)
+POPULATION_METRIC = Metric(
+    aggregation=Aggregations.SUM,
+    column="population",
+    alias="population",
+)
+
+MOCK_ENDPOINT = "test"
+TEST_S3_PARAMS = {
+    "use_ssl": False,
+    "url_style": "path",
+    "use_credential_chain": True,
+}
+
+TEST_BUCKET_NAME = "test-bucket"
+
+os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = f"http://{MOCK_ENDPOINT}"
+os.environ["S3_IGNORE_SUBDOMAIN_BUCKETNAME"] = "true"
+
+
+@pytest.fixture()
+def mocked_s3_res(moto_server):
+    with mock_aws():
+        yield boto3.resource("s3", endpoint_url=moto_server)
+
+
+@pytest.fixture()
+def mocked_s3_client(moto_server):
+    with mock_aws():
+        yield boto3.client("s3", endpoint_url=moto_server)
+
+
+@pytest.fixture(autouse=True)
+def mock_s3_bucket(mocked_s3_res):
+    bucket = TEST_BUCKET_NAME
+    mocked_s3_res.create_bucket(Bucket=bucket)
+    return bucket
+
+
+def file_name_as_key(prefix, file_name) -> str:
+    return f"{prefix}/{os.path.basename(file_name)}"
+
+
+@pytest.fixture(autouse=False)
+def s3_files_prefix(mock_s3_bucket, mocked_s3_client):
+    prefix = f"test_join-{uuid4()}"
+    for file_name in files:
+        mocked_s3_client.upload_file(
+            Filename=file_name,
+            Bucket=mock_s3_bucket,
+            Key=file_name_as_key(prefix=prefix, file_name=file_name),
+        )
+    yield prefix
+    for object_name in [file_name_as_key(prefix=prefix, file_name=f) for f in files]:
+        mocked_s3_client.delete_object(
+            Bucket=mock_s3_bucket,
+            Key=object_name,
+        )
+
+
+@pytest.fixture
+def moto_server():
+    server = ThreadedMotoServer(port=0)
+    server.start()
+    host, port = server.get_host_and_port()
+    yield f"http://{host}:{port}"
+    server.stop()
+
+
+class TestJoinExpressions:
+
+    @pytest.fixture()
+    def joined_config(self, mock_s3_bucket):
+        return Config(
+            datasource=DataSource(
+                connection_type="s3",
+                parameters={"bucket": mock_s3_bucket, "key": "", **TEST_S3_PARAMS},
+            ),
+            redaction_expression=REDACTION_EXPRESSION,
+            datasets=[
+                DatasetConfig(
+                    name="joined",
+                    dimensions=INCIDENCE_DIMENSIONS + ["population"],
+                    metrics=[INCIDENCE_METRIC, POPULATION_METRIC],
+                    output_file="joined.csv",
+                    sql=JOIN_SQL,
+                    suppression_strategies=[
+                        MarkRedacted(
+                            parameters=MarkRedactedParameters(redacted_dimension="age")
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    def test_join_expression_redaction(
+        self,
+        s3_files_prefix,
+        mock_s3_bucket,
+        joined_config,
+        moto_server,
+    ):
+        engine = Engine(
+            config=joined_config,
+            output_prefix=s3_files_prefix,
+            output_bucket=mock_s3_bucket,
+        )
+        engine.connector.endpoint = moto_server.replace("http://", "")
+        incidence_file = engine.get_absolute_source_file("test_joins_incidence.csv")
+        population_file = engine.get_absolute_source_file("test_joins_population.csv")
+        engine.datasets[0].sql = engine.datasets[0].sql.format(
+            incidence_file=incidence_file, population_file=population_file
+        )
+        engine.run()
+        validation_sql = f"select x from (select * from '{engine.datasets[0].output_file}' where (is_anonymous <> expected_to_be_anonymous) or (is_redacted <> expected_to_be_redacted)) x"
+        result = engine.db.sql(validation_sql).fetchall()
+        assert not result


### PR DESCRIPTION
this supports a use case in which the data delivered to s3 is relatively normalized;

add a `sql` property to the `dataset` that can be read instead of a source_file