### PR TITLE
allow for distinct initial metrics from subsequent metrics

### DIFF
--- a/ostrich_egg/config.py
+++ b/ostrich_egg/config.py
@@ -189,8 +189,7 @@ class Metric(BaseModel):
     )
     is_subsequent: bool = Field(
         description="Whether this metric is a subsequent metric that runs after the initial metric. It is by default the opposite of is_initial; a metric could be the same for both, especially if already a a sum or average or any_value aggregation.",
-        default_factory=lambda data: not data['is_initial'],
-
+        default_factory=lambda data: not data["is_initial"],
     )
 
     def render_as_sql_expression(self, include_alias=False):
@@ -218,7 +217,7 @@ class Metric(BaseModel):
 
     def should_include_in_initial_state(self, initial: bool = False):
         initial_conditions_match = self.is_initial == initial
-        counter_condition_does_not_exclude = (not initial and self.is_subsequent)
+        counter_condition_does_not_exclude = not initial and self.is_subsequent
         return initial_conditions_match or counter_condition_does_not_exclude
 
 

--- a/ostrich_egg/engine.py
+++ b/ostrich_egg/engine.py
@@ -98,10 +98,11 @@ class Engine:
 
     @active_dataset.setter
     def active_dataset(self, dataset: DatasetConfig | None):
+        self.__active_dataset = dataset
         self.metrics = dataset.metrics
         self.active_dimensions = dataset.dimensions
         self.removed_dimensions = []
-        self.__active_dataset = dataset
+
 
     @property
     def metrics(self):
@@ -121,27 +122,29 @@ class Engine:
             if self.active_dataset.unit_level_id:
                 aggregation = Aggregations.COUNT_DISTINCT
                 column = self.active_dataset.unit_level_id
-            metrics = [Metric(aggregation=aggregation, column=column)]
+            metrics = [
+                Metric(aggregation=aggregation, column=column, is_initial=True)]
         for index, metric in enumerate(metrics):
             metric.alias = metric.alias or f"m_{index}"
+        if len(metrics) == 1 and metrics[0].is_initial:
+            metrics.append(Metric(aggregation=Aggregations.SUM, column=metrics[0].alias, is_initial=False, alias=metrics[0].alias))
         self.__metrics = metrics
 
-    @property
-    def metric_aliases(self) -> dict:
+    def get_metric_aliases(self, initial: bool = False) -> dict:
         """
         Return column-name: metric-name mapping.
         """
         metric_aliases = {
-            metric.alias: metric.render_as_sql_expression() for metric in self.metrics
+            metric.alias: metric.render_as_sql_expression() for metric in self.metrics if metric.should_include_in_initial_state(initial=initial)
         }
         return metric_aliases
 
-    @property
-    def metric_sql_list(self) -> list:
-        return [
-            f"{metric} as {identifier(alias)}"
-            for alias, metric in self.metric_aliases.items()
-        ]
+    def get_metric_sql_list(self, initial: bool = False) -> list:
+            metric_sql_list =  [
+                f"{metric} as {identifier(alias)}"
+                for alias, metric in self.get_metric_aliases(initial=initial).items()
+            ]
+            return metric_sql_list
 
     @property
     def redaction_expression(self) -> str:
@@ -245,7 +248,7 @@ class Engine:
             )
         return whens
 
-    def get_wrapper_metrics_pass_expression_from_redaction_expression(self) -> str:
+    def get_wrapper_metrics_pass_expression_from_redaction_expression(self, initial: bool = False) -> str:
         """
         Construct the expression that determines if the row itself passes privacy thresholds
         It evaluates the redaction expression and returns a single boolean for whether the row in question passes.
@@ -257,7 +260,7 @@ class Engine:
         {%- endfor %}
         """
         context = {
-            "metric_aliases": self.metric_aliases,
+            "metric_aliases": self.get_metric_aliases(initial=initial),
             "allow_zeroes": self.allow_zeros,
             "threshold": self.threshold,
         }
@@ -266,14 +269,14 @@ class Engine:
         return check_for_did_not_pass
 
     def get_rendered_aggregation_query(
-        self, dimensions: list = None, table_name: str = None
+        self, dimensions: list = None, table_name: str = None, initial: bool = False
     ) -> str:
         dimensions = dimensions or self.active_dimensions
         dimensions_as_sql_object = self.dimensions_as_sql_expressions(
             dimensions=dimensions
         )
         context = {
-            "metric_list": self.metric_sql_list,
+            "metric_list": self.get_metric_sql_list(initial=initial),
             "dimensions": dimensions_as_sql_object,
             "table_name": table_name or self.connector.table_name,
             # "wrapper_list_check": self.get_wrapper_metrics_pass_expression_from_redaction_expression(),
@@ -305,7 +308,7 @@ class Engine:
         """
         dimensions = dimensions or self.active_dimensions
         sql = self.get_rendered_aggregation_query(
-            dimensions=dimensions, table_name=table_name
+            dimensions=dimensions, table_name=table_name, initial=initial
         )
         __result__ = self.connector.duckdb_connection.sql(sql)
         if initial:
@@ -357,8 +360,8 @@ class Engine:
         sql_expressions = self.dimensions_as_sql_expressions(
             dimensions=dimensions_to_hold_constant
         )
-        metrics_sql = ", ".join(self.metric_sql_list)
-        metric_sort = ", ".join(self.metric_aliases.keys())
+        metrics_sql = ", ".join(self.get_metric_sql_list(initial=False))
+        metric_sort = ", ".join(self.get_metric_aliases(initial=False).keys())
         anonymous_metric = "count(*) filter (where not is_anonymous) = 0"
         dimension_value_count_sql = f"""
         select dense_rank() over(order by {sql_expressions.aliases}) as peer_id , *
@@ -409,7 +412,7 @@ class Engine:
                 .select(
                     DIMENSION_VALUE_COLUMN,
                     IS_ANONYMOUS_COLUMN,
-                    *self.metric_aliases.keys(),
+                    *self.get_metric_aliases(initial=False).keys(),
                 )
                 .order(metric_sort)
             )
@@ -471,7 +474,7 @@ class Engine:
         """
                 )
                 sql = working_subtotal_query_template.render(
-                    metric_list=self.metric_sql_list,
+                    metric_list=self.get_metric_sql_list(initial=False),
                     anonymous_expression=self.anonymous_expression,
                     is_anonymous=IS_ANONYMOUS_COLUMN,
                 )
@@ -652,7 +655,7 @@ class Engine:
                 page_redactions = (
                     self.get_dimension_values_to_redact_with_latency_check(
                         dimension=dimension_to_use,
-                        metric_name=list(self.metric_aliases.keys())[0],
+                        metric_name=list(self.get_metric_aliases(initial=False).keys())[0],
                     )
                 )
                 redactions.extend(page_redactions)
@@ -660,7 +663,7 @@ class Engine:
             self.connector.duckdb_connection.register("result", result_table)
             redactions = self.get_dimension_values_to_redact_with_latency_check(
                 dimension=dimension_to_use,
-                metric_name=list(self.metric_aliases.keys())[0],
+                metric_name=list(self.get_metric_aliases(initial=False).keys())[0],
             )
         alter_sql = """
         alter table output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ sys.path.insert(1, SRC_DIRECTORY)
 sys.path.insert(2, TEST_DIRECTORY)
 
 
+DATA_INPUTS_DIRECTORY = os.path.join(TEST_DIRECTORY, "data_inputs")
+DATA_OUTPUTS_DIRECTORY = os.path.join(TEST_DIRECTORY, "data_outputs")
+
 MOCK_ENDPOINT = "test"
 TEST_S3_PARAMS = {
     "use_ssl": False,

--- a/tests/data_inputs/count_based.json
+++ b/tests/data_inputs/count_based.json
@@ -1,0 +1,27 @@
+[
+    {
+        "count": 10,
+        "month": "2025-01",
+        "county": "A",
+        "zip_code": "12345",
+        "zip_code_population": 3000,
+        "purpose": "Provide 1 small cell that will force latent suppression."
+    },
+    {
+        "count": 20,
+        "month": "2025-01",
+        "county": "A",
+        "zip_code": "23456",
+        "zip_code_population": 4000,
+        "demographics": "Profile-A",
+        "purpose": "Be latently suppressed."
+    },
+    {
+        "count": 21,
+        "month": "2025-01",
+        "county": "B",
+        "zip_code": "23456",
+        "zip_code_population": 4000,
+        "purpose": "Be displayed, not suppressed."
+    }
+]

--- a/tests/test_compound_threshold_expression.py
+++ b/tests/test_compound_threshold_expression.py
@@ -100,11 +100,13 @@ def compound_redaction_expression_config() -> Config:
                         aggregation=Aggregations.SUM,
                         column="incidence",
                         alias="incidence",
+                        is_initial=True,
                     ),
                     Metric(
                         aggregation=Aggregations.SUM,
                         column="population",
                         alias="population",
+                        is_initial=True,
                     ),
                 ],
                 suppression_strategies=[

--- a/tests/test_initial_metrics.py
+++ b/tests/test_initial_metrics.py
@@ -1,0 +1,132 @@
+import os
+import pytest
+
+from conftest import DATA_INPUTS_DIRECTORY, DATA_OUTPUTS_DIRECTORY
+from engine import Engine
+from config import (
+    Config,
+    MarkRedacted,
+    MarkRedactedParameters,
+    DatasetConfig,
+    DataSource,
+    Metric,
+    Aggregations,
+)
+
+test_file = os.path.join(DATA_INPUTS_DIRECTORY, "count_based.json")
+
+generate_sql = f"""
+    select row_number() over() as id, *
+    from '{test_file}', generate_series(1, count) as gen
+"""
+
+REDACTION_EXPRESSION = """\
+case
+    when incidence < 11 and population >= 2500 and population < 20000 then true
+    when population >= 20000 then false
+    when population < 2500 then true
+    else false
+end
+"""
+
+DIMENSIONS = [
+    "month",
+    "county",
+    "zip_code",
+]
+
+INITIAL_INCIDENCE_METRIC = Metric(
+    aggregation=Aggregations.COUNT,
+    column="*",
+    alias="incidence",
+    is_initial=True,
+)
+SUBSEQUENT_INCIDENCE_METRIC = Metric(
+    aggregation=Aggregations.SUM,
+    column="incidence",
+    alias="incidence",
+    is_initial=False,
+)
+INITIAL_POPULATION_METRIC = Metric(
+    aggregation=Aggregations.ANY_VALUE,
+    column="zip_code_population",
+    alias="population",
+    is_initial=True,
+)
+SUBSEQUENT_POPULATION_METRIC = Metric(
+    aggregation=Aggregations.ANY_VALUE,
+    column="population",
+    alias="population",
+    is_initial=False,
+)
+
+class TestInitialMetrics:
+
+    @pytest.fixture()
+    def implicit_config(self):
+        return Config(
+            datasource=DataSource(
+                connection_type="file",
+                parameters={"file_path": test_file, "output_directory": DATA_OUTPUTS_DIRECTORY},
+            ),
+            datasets=[
+                DatasetConfig(
+                    name="base",
+                    dimensions=DIMENSIONS,
+                    unit_level_id="id",
+                    output_file="implicit_metric.csv",
+                    sql=generate_sql,
+                    suppression_strategies=[
+                        MarkRedacted(
+                            parameters=MarkRedactedParameters(redacted_dimension="zip_code")
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    @pytest.fixture()
+    def explicit_config(self):
+        return Config(
+            datasource=DataSource(
+                connection_type="file",
+                parameters={"file_path": test_file, "output_directory": DATA_OUTPUTS_DIRECTORY},
+            ),
+            redaction_expression=REDACTION_EXPRESSION,
+            datasets=[
+                DatasetConfig(
+                    name="base",
+                    dimensions=DIMENSIONS,
+                    unit_level_id="id",
+                    metrics=[INITIAL_INCIDENCE_METRIC, SUBSEQUENT_INCIDENCE_METRIC, INITIAL_POPULATION_METRIC, SUBSEQUENT_POPULATION_METRIC],
+                    output_file="implicit_metric.csv",
+                    sql=generate_sql,
+                    suppression_strategies=[
+                        MarkRedacted(
+                            parameters=MarkRedactedParameters(redacted_dimension="zip_code")
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    def test_implicit_metric(self, implicit_config):
+        """
+        Assert that the default metric situation for a row-level counting dataset iterates on the aggregations appropriately.
+        """
+        engine = Engine(config=implicit_config)
+        engine.run()
+        assert str(engine.metrics[0].aggregation) == "count_distinct"
+        assert str(engine.metrics[1].aggregation) == "sum"
+
+    def test_explicit_subsequent_metric(self, explicit_config):
+        """
+        Assert that the explicit metric situation for a row-level counting dataset iterates on the aggregations appropriately.
+        """
+        engine = Engine(config=explicit_config)
+        engine.run()
+        output = engine.db.read_csv(engine.active_dataset.output_file)
+        results = [r[0] for r in engine.db.sql("select output from output").fetchall()]
+        assert {'incidence': 20, 'population': 4000, 'month': '2025-01', 'county': 'A', 'zip_code': 23456, 'is_anonymous': True, 'is_redacted': True} in results
+        assert {'incidence': 10, 'population': 3000, 'month': '2025-01', 'county': 'A', 'zip_code': 12345, 'is_anonymous': False, 'is_redacted': True} in results
+        assert {'incidence': 21, 'population': 4000, 'month': '2025-01', 'county': 'B', 'zip_code': 23456, 'is_anonymous': True, 'is_redacted': False} in results

--- a/tests/test_initial_metrics.py
+++ b/tests/test_initial_metrics.py
@@ -60,6 +60,7 @@ SUBSEQUENT_POPULATION_METRIC = Metric(
     is_initial=False,
 )
 
+
 class TestInitialMetrics:
 
     @pytest.fixture()
@@ -67,7 +68,10 @@ class TestInitialMetrics:
         return Config(
             datasource=DataSource(
                 connection_type="file",
-                parameters={"file_path": test_file, "output_directory": DATA_OUTPUTS_DIRECTORY},
+                parameters={
+                    "file_path": test_file,
+                    "output_directory": DATA_OUTPUTS_DIRECTORY,
+                },
             ),
             datasets=[
                 DatasetConfig(
@@ -78,7 +82,9 @@ class TestInitialMetrics:
                     sql=generate_sql,
                     suppression_strategies=[
                         MarkRedacted(
-                            parameters=MarkRedactedParameters(redacted_dimension="zip_code")
+                            parameters=MarkRedactedParameters(
+                                redacted_dimension="zip_code"
+                            )
                         )
                     ],
                 ),
@@ -90,7 +96,10 @@ class TestInitialMetrics:
         return Config(
             datasource=DataSource(
                 connection_type="file",
-                parameters={"file_path": test_file, "output_directory": DATA_OUTPUTS_DIRECTORY},
+                parameters={
+                    "file_path": test_file,
+                    "output_directory": DATA_OUTPUTS_DIRECTORY,
+                },
             ),
             redaction_expression=REDACTION_EXPRESSION,
             datasets=[
@@ -98,12 +107,19 @@ class TestInitialMetrics:
                     name="base",
                     dimensions=DIMENSIONS,
                     unit_level_id="id",
-                    metrics=[INITIAL_INCIDENCE_METRIC, SUBSEQUENT_INCIDENCE_METRIC, INITIAL_POPULATION_METRIC, SUBSEQUENT_POPULATION_METRIC],
+                    metrics=[
+                        INITIAL_INCIDENCE_METRIC,
+                        SUBSEQUENT_INCIDENCE_METRIC,
+                        INITIAL_POPULATION_METRIC,
+                        SUBSEQUENT_POPULATION_METRIC,
+                    ],
                     output_file="implicit_metric.csv",
                     sql=generate_sql,
                     suppression_strategies=[
                         MarkRedacted(
-                            parameters=MarkRedactedParameters(redacted_dimension="zip_code")
+                            parameters=MarkRedactedParameters(
+                                redacted_dimension="zip_code"
+                            )
                         )
                     ],
                 ),
@@ -125,8 +141,32 @@ class TestInitialMetrics:
         """
         engine = Engine(config=explicit_config)
         engine.run()
-        output = engine.db.read_csv(engine.active_dataset.output_file)
+        output = engine.db.read_csv(engine.active_dataset.output_file)  # noqa: F841
         results = [r[0] for r in engine.db.sql("select output from output").fetchall()]
-        assert {'incidence': 20, 'population': 4000, 'month': '2025-01', 'county': 'A', 'zip_code': 23456, 'is_anonymous': True, 'is_redacted': True} in results
-        assert {'incidence': 10, 'population': 3000, 'month': '2025-01', 'county': 'A', 'zip_code': 12345, 'is_anonymous': False, 'is_redacted': True} in results
-        assert {'incidence': 21, 'population': 4000, 'month': '2025-01', 'county': 'B', 'zip_code': 23456, 'is_anonymous': True, 'is_redacted': False} in results
+        assert {
+            "incidence": 20,
+            "population": 4000,
+            "month": "2025-01",
+            "county": "A",
+            "zip_code": 23456,
+            "is_anonymous": True,
+            "is_redacted": True,
+        } in results
+        assert {
+            "incidence": 10,
+            "population": 3000,
+            "month": "2025-01",
+            "county": "A",
+            "zip_code": 12345,
+            "is_anonymous": False,
+            "is_redacted": True,
+        } in results
+        assert {
+            "incidence": 21,
+            "population": 4000,
+            "month": "2025-01",
+            "county": "B",
+            "zip_code": 23456,
+            "is_anonymous": True,
+            "is_redacted": False,
+        } in results


### PR DESCRIPTION
Sometimes, you get a dataset that you need to start `count(*)`, and then you need to compare redactions by summing that metric. 

for example, first you need to`count(*) as incidence` from vaccine-level data to get the initial aggregation. Then to do latent checks to you need to compare incidences; if you forget to do this and count(*) again from that initial aggregation that gets cached, you'll accidentally count your aggregated rows, which is undesirable as  you are comparing the wrong metric for redaction.